### PR TITLE
Misc Fixes

### DIFF
--- a/launch/localization.launch.py
+++ b/launch/localization.launch.py
@@ -73,7 +73,7 @@ def launch_setup(context, *args, **kwargs):
     clearpath_config = ClearpathConfig(config)
 
     namespace = clearpath_config.system.namespace
-    platform_model = clearpath_config.platform.get_model()
+    platform_model = clearpath_config.platform.get_platform_model()
 
     file_parameters = PathJoinSubstitution([
         pkg_clearpath_nav2_demos,

--- a/launch/nav2.launch.py
+++ b/launch/nav2.launch.py
@@ -44,7 +44,7 @@ from launch.substitutions import (
     PathJoinSubstitution
 )
 
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import PushRosNamespace, SetRemap
 
 
 ARGUMENTS = [
@@ -85,6 +85,8 @@ def launch_setup(context, *args, **kwargs):
 
     nav2 = GroupAction([
         PushRosNamespace(namespace),
+        SetRemap(namespace + '/global_costmap/sensors/lidar2d_0/scan', namespace + '/sensors/lidar2d_0/scan'),
+        SetRemap(namespace + '/local_costmap/sensors/lidar2d_0/scan', namespace + '/sensors/lidar2d_0/scan'),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(launch_nav2),

--- a/launch/nav2.launch.py
+++ b/launch/nav2.launch.py
@@ -85,8 +85,10 @@ def launch_setup(context, *args, **kwargs):
 
     nav2 = GroupAction([
         PushRosNamespace(namespace),
-        SetRemap(namespace + '/global_costmap/sensors/lidar2d_0/scan', namespace + '/sensors/lidar2d_0/scan'),
-        SetRemap(namespace + '/local_costmap/sensors/lidar2d_0/scan', namespace + '/sensors/lidar2d_0/scan'),
+        SetRemap('/' + namespace + '/global_costmap/sensors/lidar2d_0/scan',
+                 '/' + namespace + '/sensors/lidar2d_0/scan'),
+        SetRemap('/' + namespace + '/local_costmap/sensors/lidar2d_0/scan',
+                 '/' + namespace + '/sensors/lidar2d_0/scan'),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(launch_nav2),

--- a/launch/nav2.launch.py
+++ b/launch/nav2.launch.py
@@ -72,7 +72,7 @@ def launch_setup(context, *args, **kwargs):
     clearpath_config = ClearpathConfig(config)
 
     namespace = clearpath_config.system.namespace
-    platform_model = clearpath_config.platform.get_model()
+    platform_model = clearpath_config.platform.get_platform_model()
 
     file_parameters = PathJoinSubstitution([
         pkg_clearpath_nav2_demos,

--- a/launch/slam.launch.py
+++ b/launch/slam.launch.py
@@ -70,7 +70,7 @@ def launch_setup(context, *args, **kwargs):
     clearpath_config = ClearpathConfig(config)
 
     namespace = clearpath_config.system.namespace
-    platform_model = clearpath_config.platform.get_model()
+    platform_model = clearpath_config.platform.get_platform_model()
 
     file_parameters = PathJoinSubstitution([
         pkg_clearpath_nav2_demos,
@@ -98,7 +98,7 @@ def launch_setup(context, *args, **kwargs):
         remappings=[
           ('/tf', 'tf'),
           ('/tf_static', 'tf_static'),
-          ('/scan', 'platform/sensors/lidar2d_0/scan'),
+          ('/scan', 'sensors/lidar2d_0/scan'),
           ('/map', 'map'),
           ('/map_metadata', 'map_metadata'),
         ]


### PR DESCRIPTION
Updates to match the 0.1.0 release of clearpath config and remap the nav2 scan topics such that local and global costmap plugins subscribe to the correct scan topic and thus can plan around unmapped objects.

Related to:
https://github.com/clearpathrobotics/clearpath_common/pull/31
https://github.com/clearpathrobotics/clearpath_simulator/pull/15
https://github.com/clearpathrobotics/clearpath_desktop/pull/9