### PR TITLE
use_sim_time should not be in the yaml in Jazzy

### DIFF
--- a/config/a200/localization.yaml
+++ b/config/a200/localization.yaml
@@ -1,6 +1,5 @@
 amcl:
   ros__parameters:
-    use_sim_time: True
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
@@ -39,16 +38,8 @@ amcl:
     z_short: 0.05
     scan_topic: sensors/lidar2d_0/scan
 
-map_server:
-  ros__parameters:
-    use_sim_time: True
-    # Overridden in launch by the "map" launch configuration or provided default value.
-    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
-    yaml_filename: ""
-
 map_saver:
   ros__parameters:
-    use_sim_time: True
     save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65

--- a/config/a200/nav2.yaml
+++ b/config/a200/nav2.yaml
@@ -1,6 +1,5 @@
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     global_frame: map
     robot_base_frame: base_link
@@ -61,17 +60,14 @@ bt_navigator:
 
 bt_navigator_navigate_through_poses_rclcpp_node:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
 
 bt_navigator_navigate_to_pose_rclcpp_node:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
 
 controller_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
@@ -148,7 +144,6 @@ local_costmap:
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       rolling_window: true
       width: 5
@@ -192,7 +187,6 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       footprint: "[ [0.55, 0.45], [0.55, -0.45], [-0.55, -0.45], [-0.55, 0.45] ]"
       resolution: 0.06
@@ -224,7 +218,6 @@ global_costmap:
 planner_server:
   ros__parameters:
     expected_planner_frequency: 20.0
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     planner_plugins: ["GridBased"]
     GridBased:
@@ -235,7 +228,6 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
@@ -263,20 +255,14 @@ behavior_server:
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    use_sim_time: true
     enable_stamped_cmd_vel: True
     simulate_ahead_time: 2.0
     max_rotational_vel: 1.0
     min_rotational_vel: 0.2
     rotational_acc_lim: 0.5
 
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: True
-
 waypoint_follower:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     loop_rate: 20
     stop_on_failure: false
@@ -288,7 +274,6 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoothing_frequency: 20.0
     scale_velocities: False

--- a/config/a300/localization.yaml
+++ b/config/a300/localization.yaml
@@ -1,6 +1,5 @@
 amcl:
   ros__parameters:
-    use_sim_time: True
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
@@ -39,16 +38,8 @@ amcl:
     z_short: 0.05
     scan_topic: sensors/lidar2d_0/scan
 
-map_server:
-  ros__parameters:
-    use_sim_time: True
-    # Overridden in launch by the "map" launch configuration or provided default value.
-    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
-    yaml_filename: ""
-
 map_saver:
   ros__parameters:
-    use_sim_time: True
     save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65

--- a/config/a300/nav2.yaml
+++ b/config/a300/nav2.yaml
@@ -1,6 +1,5 @@
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
     global_frame: map
     robot_base_frame: base_link
     odom_topic: platform/odom/filtered
@@ -58,17 +57,8 @@ bt_navigator:
     - nav2_assisted_teleop_cancel_bt_node
     - nav2_drive_on_heading_cancel_bt_node
 
-bt_navigator_navigate_through_poses_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
-bt_navigator_navigate_to_pose_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
 controller_server:
   ros__parameters:
-    use_sim_time: True
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
@@ -142,7 +132,6 @@ local_costmap:
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
-      use_sim_time: True
       rolling_window: true
       width: 5
       height: 5
@@ -185,7 +174,6 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link
-      use_sim_time: True
       footprint: "[ [0.495, 0.349], [0.495, -0.349], [-0.495, -0.349], [-0.495, 0.349] ]"
       resolution: 0.06
       track_unknown_space: true
@@ -216,7 +204,6 @@ global_costmap:
 planner_server:
   ros__parameters:
     expected_planner_frequency: 20.0
-    use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
       plugin: "nav2_navfn_planner/NavfnPlanner"
@@ -226,7 +213,6 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: True
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
       plugin: "nav2_smoother::SimpleSmoother"
@@ -253,19 +239,13 @@ behavior_server:
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    use_sim_time: true
     simulate_ahead_time: 2.0
     max_rotational_vel: 1.0
     min_rotational_vel: 0.2
     rotational_acc_lim: 0.5
 
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: True
-
 waypoint_follower:
   ros__parameters:
-    use_sim_time: True
     loop_rate: 20
     stop_on_failure: false
     waypoint_task_executor_plugin: "wait_at_waypoint"
@@ -276,7 +256,6 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: True
     smoothing_frequency: 20.0
     scale_velocities: False
     feedback: "OPEN_LOOP"

--- a/config/j100/localization.yaml
+++ b/config/j100/localization.yaml
@@ -1,6 +1,5 @@
 amcl:
   ros__parameters:
-    use_sim_time: True
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
@@ -39,16 +38,8 @@ amcl:
     z_short: 0.05
     scan_topic: sensors/lidar2d_0/scan
 
-map_server:
-  ros__parameters:
-    use_sim_time: True
-    # Overridden in launch by the "map" launch configuration or provided default value.
-    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
-    yaml_filename: ""
-
 map_saver:
   ros__parameters:
-    use_sim_time: True
     save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65

--- a/config/j100/nav2.yaml
+++ b/config/j100/nav2.yaml
@@ -1,6 +1,5 @@
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     global_frame: map
     robot_base_frame: base_link
@@ -61,17 +60,14 @@ bt_navigator:
 
 bt_navigator_navigate_through_poses_rclcpp_node:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
 
 bt_navigator_navigate_to_pose_rclcpp_node:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
 
 controller_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
@@ -146,7 +142,6 @@ local_costmap:
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       rolling_window: true
       width: 5
@@ -190,7 +185,6 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       footprint: "[ [0.254, 0.2159], [0.254, -0.2159], [-0.254, -0.2159], [-0.254, 0.2159] ]"
       resolution: 0.06
@@ -222,7 +216,6 @@ global_costmap:
 planner_server:
   ros__parameters:
     expected_planner_frequency: 20.0
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     planner_plugins: ["GridBased"]
     GridBased:
@@ -233,7 +226,6 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
@@ -261,20 +253,14 @@ behavior_server:
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    use_sim_time: true
     enable_stamped_cmd_vel: True
     simulate_ahead_time: 2.0
     max_rotational_vel: 1.0
     min_rotational_vel: 0.2
     rotational_acc_lim: 0.5
 
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: True
-
 waypoint_follower:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     loop_rate: 20
     stop_on_failure: false
@@ -286,7 +272,6 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoothing_frequency: 20.0
     scale_velocities: False

--- a/config/w200/localization.yaml
+++ b/config/w200/localization.yaml
@@ -1,6 +1,5 @@
 amcl:
   ros__parameters:
-    use_sim_time: True
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
@@ -39,16 +38,8 @@ amcl:
     z_short: 0.05
     scan_topic: sensors/lidar2d_0/scan
 
-map_server:
-  ros__parameters:
-    use_sim_time: True
-    # Overridden in launch by the "map" launch configuration or provided default value.
-    # To use in yaml, remove the default "map" value in the tb3_simulation_launch.py file & provide full path to map below.
-    yaml_filename: ""
-
 map_saver:
   ros__parameters:
-    use_sim_time: True
     save_map_timeout: 5.0
     free_thresh_default: 0.25
     occupied_thresh_default: 0.65

--- a/config/w200/nav2.yaml
+++ b/config/w200/nav2.yaml
@@ -1,6 +1,5 @@
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     global_frame: map
     robot_base_frame: base_link
@@ -59,17 +58,8 @@ bt_navigator:
     - nav2_assisted_teleop_cancel_bt_node
     - nav2_drive_on_heading_cancel_bt_node
 
-bt_navigator_navigate_through_poses_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
-bt_navigator_navigate_to_pose_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
 controller_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
@@ -146,7 +136,6 @@ local_costmap:
       publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       rolling_window: true
       width: 5
@@ -190,7 +179,6 @@ global_costmap:
       publish_frequency: 1.0
       global_frame: map
       robot_base_frame: base_link
-      use_sim_time: True
       enable_stamped_cmd_vel: True
       footprint: "[ [0.76, 0.69], [0.76, -0.69], [-0.76, -0.69], [-0.76, 0.69] ]"
       resolution: 0.06
@@ -222,7 +210,6 @@ global_costmap:
 planner_server:
   ros__parameters:
     expected_planner_frequency: 20.0
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     planner_plugins: ["GridBased"]
     GridBased:
@@ -233,7 +220,6 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
@@ -261,20 +247,15 @@ behavior_server:
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    use_sim_time: true
     enable_stamped_cmd_vel: True
     simulate_ahead_time: 2.0
     max_rotational_vel: 1.0
     min_rotational_vel: 0.2
     rotational_acc_lim: 0.5
 
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: True
 
 waypoint_follower:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     loop_rate: 20
     stop_on_failure: false
@@ -286,7 +267,6 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: True
     enable_stamped_cmd_vel: True
     smoothing_frequency: 20.0
     scale_velocities: False


### PR DESCRIPTION
Between Humble and Jazzy, a change was made in how use_sim_time is set in the Nav2 launch file. Now if we have it in the yaml, that actually overrides what is passed in to the launch file. This was discovered on Turtlebot4. 

See https://github.com/ros-navigation/navigation2/commit/7703c816a11368fb1a48663dc92e4e93affb637e