### PR TITLE
Fix `slam.launch.py` to start the lifecycle node

### DIFF
--- a/launch/slam.launch.py
+++ b/launch/slam.launch.py
@@ -33,15 +33,18 @@ from clearpath_config.common.utils.yaml import read_yaml
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
-    OpaqueFunction
+    GroupAction,
+    IncludeLaunchDescription,
+    OpaqueFunction,
 )
-
+from launch.conditions import IfCondition, UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import (
     LaunchConfiguration,
-    PathJoinSubstitution
+    PathJoinSubstitution,
 )
 
-from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace, SetRemap
 
 from nav2_common.launch import RewrittenYaml
 
@@ -52,17 +55,30 @@ ARGUMENTS = [
                           description='Use sim time'),
     DeclareLaunchArgument('setup_path',
                           default_value='/etc/clearpath/',
-                          description='Clearpath setup path')
+                          description='Clearpath setup path'),
+    DeclareLaunchArgument('autostart', default_value='true',
+                          choices=['true', 'false'],
+                          description='Automatically startup the slamtoolbox. Ignored when use_lifecycle_manager is true.'),  # noqa: E501
+    DeclareLaunchArgument('use_lifecycle_manager', default_value='false',
+                          choices=['true', 'false'],
+                          description='Enable bond connection during node activation'),
+    DeclareLaunchArgument('sync', default_value='true',
+                          choices=['true', 'false'],
+                          description='Use synchronous SLAM'),
 ]
 
 
 def launch_setup(context, *args, **kwargs):
     # Packages
     pkg_clearpath_nav2_demos = get_package_share_directory('clearpath_nav2_demos')
+    pkg_slam_toolbox = get_package_share_directory('slam_toolbox')
 
     # Launch Configurations
     use_sim_time = LaunchConfiguration('use_sim_time')
     setup_path = LaunchConfiguration('setup_path')
+    autostart = LaunchConfiguration('autostart')
+    use_lifecycle_manager = LaunchConfiguration('use_lifecycle_manager')
+    sync = LaunchConfiguration('sync')
 
     # Read robot YAML
     config = read_yaml(setup_path.perform(context) + 'robot.yaml')
@@ -85,24 +101,43 @@ def launch_setup(context, *args, **kwargs):
         convert_types=True
     )
 
-    slam = Node(
-        package='slam_toolbox',
-        executable='async_slam_toolbox_node',
-        name='slam_toolbox',
-        namespace=namespace,
-        output='screen',
-        parameters=[
-          rewritten_parameters,
-          {'use_sim_time': use_sim_time}
-        ],
-        remappings=[
-          ('/tf', 'tf'),
-          ('/tf_static', 'tf_static'),
-          ('/scan', 'sensors/lidar2d_0/scan'),
-          ('/map', 'map'),
-          ('/map_metadata', 'map_metadata'),
-        ]
-    )
+    launch_slam_sync = PathJoinSubstitution(
+        [pkg_slam_toolbox, 'launch', 'online_sync_launch.py'])
+
+    launch_slam_async = PathJoinSubstitution(
+        [pkg_slam_toolbox, 'launch', 'online_async_launch.py'])
+
+    slam = GroupAction([
+        PushRosNamespace(namespace),
+
+        SetRemap('/tf', '/' + namespace + '/tf'),
+        SetRemap('/tf_static', '/' + namespace + '/tf_static'),
+        SetRemap('/scan', '/' + namespace + '/scan'),
+        SetRemap('/map', '/' + namespace + '/map'),
+        SetRemap('/map_metadata', '/' + namespace + '/map_metadata'),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(launch_slam_sync),
+            launch_arguments=[
+                ('use_sim_time', use_sim_time),
+                ('autostart', autostart),
+                ('use_lifecycle_manager', use_lifecycle_manager),
+                ('slam_params_file', rewritten_parameters)
+            ],
+            condition=IfCondition(sync)
+        ),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(launch_slam_async),
+            launch_arguments=[
+                ('use_sim_time', use_sim_time),
+                ('autostart', autostart),
+                ('use_lifecycle_manager', use_lifecycle_manager),
+                ('slam_params_file', rewritten_parameters)
+            ],
+            condition=UnlessCondition(sync)
+        )
+    ])
 
     return [slam]
 


### PR DESCRIPTION
Update SLAM launch file to start lifecycle nodes. Adds `sync` parameter to optionally toggle between synchronous & async SLAM.

Tested in simulation with robot.yaml:
```yaml
serial_number: a300-0000
version: 0
system:
  hosts:
    - hostname: REDACTED
      ip: 127.0.0.1
  ros2:
    namespace: a300_0000
  workspaces:
    - /home/REDACTED/clearpath_ws/install/setup.bash
platform:
  enable_ekf: true
  controller: ps4
  extras:
    ros_parameters:
      ekf_node:
        imu0: 'sensors/imu_0/data_raw'
        imu0_config: [False, False, False, False, False, False, False, False, False, False, False, True, True, False, False]
        imu0_differential: False
        imu0_queue_size: 10
        imu0_remove_gravitational_acceleration: True
      platform_velocity_controller:
        wheel_separation_multiplier: 1.75
        wheels_per_side: 2
  attachments:
    - name: front_bumper
      type: a300.bumper
      parent: front_bumper_mount
    - name: rear_bumper
      type: a300.bumper
      parent: rear_bumper_mount
    - name: top_plate
      type: a300.top_plate
sensors:
  imu:
    - model: phidgets_spatial
      urdf_enabled: true
      launch_enabled: true
      parent: base_link
      xyz: [0.059, 0.0, 0.161275]
      rpy: [0.0, 0.0, 0.0]
      ros_parameters:
        phidgets_spatial:
          data_interval_ms: 20
  lidar2d:
    - model: hokuyo_ust
      parent: default_mount
```

Confirmed that map displays properly in Rviz, lidar subscription works as expected.

Resolves https://github.com/clearpathrobotics/clearpath_nav2_demos/issues/23