### PR TITLE
Add `scan_topic` launch argument

### DIFF
--- a/launch/slam.launch.py
+++ b/launch/slam.launch.py
@@ -67,6 +67,9 @@ ARGUMENTS = [
     DeclareLaunchArgument('sync', default_value='true',
                           choices=['true', 'false'],
                           description='Use synchronous SLAM'),
+    DeclareLaunchArgument('scan_topic',
+                          default_value='',
+                          description='Override the default 2D laserscan topic')
 ]
 
 
@@ -81,6 +84,7 @@ def launch_setup(context, *args, **kwargs):
     autostart = LaunchConfiguration('autostart')
     use_lifecycle_manager = LaunchConfiguration('use_lifecycle_manager')
     sync = LaunchConfiguration('sync')
+    scan_topic = LaunchConfiguration('scan_topic')
 
     # Read robot YAML
     config = read_yaml(os.path.join(setup_path.perform(context), 'robot.yaml'))
@@ -89,6 +93,10 @@ def launch_setup(context, *args, **kwargs):
 
     namespace = clearpath_config.system.namespace
     platform_model = clearpath_config.platform.get_platform_model()
+    eval_scan_topic = scan_topic.perform(context)
+
+    if len(eval_scan_topic) == 0:
+        eval_scan_topic = f'/{namespace}/sensors/lidar2d_0/scan'
 
     file_parameters = PathJoinSubstitution([
         pkg_clearpath_nav2_demos,
@@ -101,7 +109,7 @@ def launch_setup(context, *args, **kwargs):
         root_key=namespace,
         param_rewrites={
             'map_name': '/' + namespace + '/map',
-            'scan_topic': '/' + namespace + '/sensors/lidar2d_0/scan',
+            'scan_topic': eval_scan_topic,
         },
         convert_types=True
     )


### PR DESCRIPTION
All launch files (localization, slam, nav2) now support a `scan_topic` argument to override the 2d lidar input. By default this argument is blank, indicating that `/{namespace}/sensors/lidar2d_0/scan` should be used. If the argument is specified, we rewrite the necessary parameters to subscribe to the user's specified topic.

e.g. This robot.yaml
```yaml
serial_number: a300-0000
version: 0
system:
  hosts:
    - hostname: cpr-albert
      ip: 127.0.0.1
  ros2:
    namespace: a300_0000
    domain_id: 42
    workspaces:
      - /home/robot/clearpath_common_ws/install/setup.bash
sensors:
  lidar3d:
    - model: velodyne_lidar
      urdf_enabled: true
      launch_enabled: true
      parent: base_link
      xyz: [0.0, 0.0, 0.0]
      rpy: [0.0, 0.0, 0.0]
      ros_parameters:
        velodyne_driver_node:
          frame_id: lidar3d_0_laser
          device_ip: 192.168.131.25
          port: 2368
          model: VLP16
        velodyne_transform_node:
          model: VLP16
          fixed_frame: lidar3d_0_laser
          target_frame: lidar3d_0_laser
```
does not have a 2d lidar, but does publish 2d scan data on `.../sensors/lidar3d_0/scan`. By launching the following, AMCL localization works in the simulator:
```bash
ros2 launch clearpath_gz simulation.launch.py
ros2 launch clearpath_nav2_demos localization.launch.py scan_topic:=/a300_0000/sensors/lidar3d_0/scan use_sim_time:=true
ros2 launch clearpath_nav2_demos nav2.launch.py scan_topic:=/a300_0000/sensors/lidar3d_0/scan use_sim_time:=true
ros2 launch clearpath_viz view_navigation.launch.py namespace:=/a300_0000 use_sim_time:=true
```
or for SLAM:
```bash
ros2 launch clearpath_gz simulation.launch.py
ros2 launch clearpath_nav2_demos slam.launch.py scan_topic:=/a300_0000/sensors/lidar3d_0/scan use_sim_time:=true
ros2 launch clearpath_nav2_demos nav2.launch.py scan_topic:=/a300_0000/sensors/lidar3d_0/scan use_sim_time:=true
ros2 launch clearpath_viz view_navigation.launch.py namespace:=/a300_0000 use_sim_time:=true
```